### PR TITLE
Update .travis.yml email settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ addons:
    - libboost-all-dev
 dist: trusty
 sudo: required
+notifications:
+  email: false


### PR DESCRIPTION
Set all Travis-CI emails to off for this repository. This is a non-critical project and I might push many commits, so I don't want Travis to clutter my email inbox. I will still check the Travis build status here on GitHub.